### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that enables AI agents to interact with terminal-based TUI applications through a virtual X11 display approach.
 
+<a href="https://glama.ai/mcp/servers/@taskhub-sh/terminal-driver-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@taskhub-sh/terminal-driver-mcp/badge" alt="Terminal Control MCP server" />
+</a>
+
 ## Overview
 
 This project provides a comprehensive solution for controlling terminal applications programmatically using:


### PR DESCRIPTION
This PR adds a badge for the [Terminal Control MCP](https://glama.ai/mcp/servers/@taskhub-sh/terminal-driver-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@taskhub-sh/terminal-driver-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@taskhub-sh/terminal-driver-mcp/badge" alt="Terminal Control MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.